### PR TITLE
Added support for Python 3 to chat.py

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -45,6 +45,8 @@ def read_from_user(buffer, buffer_size=1024):
 def write_to_device(device, data):
     # I suspect this fails silently if the arduino's buffer is full
     if data is not None:
+        if sys.version_info>=(3,1):
+            data = bytes(data, 'UTF-8')
         device.write(data)
 
 

--- a/chat.py
+++ b/chat.py
@@ -18,6 +18,8 @@ def write_to_user(buffer, data):
     """
     # No matter what, pipe new_lines to savefile here
     for line in data:
+        if sys.version_info>=(3,1):
+            line = str(line)
         buffer.write(line)
     buffer.flush()
 

--- a/chat.py
+++ b/chat.py
@@ -89,8 +89,11 @@ class Chatter:
             if to_user_dir is not None:
                 to_user = os.path.join(
                     os.path.realpath(to_user_dir), to_user)
-        self.ofi = file(to_user, 'w')
-
+        if sys.version_info<=(3,1):
+            self.ofi = file(to_user, 'w')
+        else:
+            self.ofi = open(to_user, 'w')
+            
         ## Set up device
         # 0 means return whatever is available immediately
         # otherwise, wait for specified time


### PR DESCRIPTION
This branch adds chat.py support for Python 3, which ends up taking only half a dozen or so lines. The main difference is that in Python 2, strings are by default stored as an array of bytes that are mapped to characters under the ASCII encoding scheme, whereas in Python 3, strings are stored as array of bytes that are mapped to Unicode "code points" under some encoding scheme like UTF-8 (which are in turn mapped to characters).

PySerial's read and write functions use Python 2-style ASCII byte arrays, so in one or two places I've introduced a conditional statement that detects the Python version and does the necessary conversions if it detects that the user is currently running Python 3.  
